### PR TITLE
feat: #15 비영 데이터 대응 & 유사도 값 범위 보장

### DIFF
--- a/transform/issue_score.py
+++ b/transform/issue_score.py
@@ -1,7 +1,8 @@
 from math import log
 
+import numpy as np
 import pandas as pd
-from scipy.spatial.distance import euclidean
+from scipy.stats import zscore
 from fastdtw import fastdtw
 
 
@@ -16,7 +17,14 @@ def get_issue_score(viewed: float, liked: float, num_of_comments: float) -> floa
     return viewed + log(1 + liked) + log(1 + num_of_comments)
 
 
-def dtw_similarity_score(x: pd.Series, y: pd.Series, radius: int = 1) -> float:
+def weighted_distance(a, b):
+    """
+    희소 시계열 데이터의 거리 계산을 위해 두 점의 거리를 가중치를 취한 거리 함수 
+    """
+    return np.abs(a - b)
+
+
+def dtw_similarity_score(a, b, scale_factor: float = 0.1, radius: int = 1) -> float:
     """
     정규화된 DTW 유사도 계산
     :param x: 그래프를 나타내는 1차원 리스트 (pd.Series)
@@ -25,21 +33,43 @@ def dtw_similarity_score(x: pd.Series, y: pd.Series, radius: int = 1) -> float:
     :return: [0,1] 사이의 실수값, 1에 가까울수록 유사한 그래프
     """
     # 입력이 pandas Series인지 확인
-    if not isinstance(x, pd.Series) or not isinstance(y, pd.Series):
-        raise TypeError("입력은 pandas Series 형태여야 합니다.")
+    if isinstance(a, pd.Series):
+        a = a.to_numpy()
+    if isinstance(b, pd.Series):
+        b = b.to_numpy()
+
+    a_x = np.arange(len(a))[a != 0]
+    b_x = np.arange(len(b))[b != 0]
+
+    a_nonzero = a[a != 0]
+    b_nonzero = b[b != 0]
+
+    num_a_nonzero = len(a_nonzero)
+    num_b_nonzero = len(b_nonzero)
+
+    # 비영 영역이 없는 경우 처리
+    if num_a_nonzero == 0 and num_b_nonzero == 0:
+        return 0.0 # 아무런 신호가 없는 경우 무시하기 위해 0 반환 
+    elif num_a_nonzero == 0 or num_b_nonzero == 0:
+        return 0.0
     
-    # fastdtw 사용
-    raw_distance, _ = fastdtw(list(x.items()), list(y.items()), dist=euclidean, radius=radius)
-    
-    # 정규화를 위한 최대 가능 거리 계산
-    max_seq = max(x.max(), y.max())
-    min_seq = min(x.min(), y.min())
-    max_distance = abs(max_seq - min_seq) * max(len(x), len(y))
-    
+    a_nonzero = zscore(a_nonzero)
+    b_nonzero = zscore(b_nonzero)
+
+    a_nonzero = np.vstack((a_x, a_nonzero)).T
+    b_nonzero = np.vstack((b_x, b_nonzero)).T
+
+    raw_distance, _ = fastdtw(a_nonzero, b_nonzero, radius=radius)
+    print(raw_distance)
+
     # 정규화된 거리 계산 (0과 1 사이의 값)
-    normalized_distance = raw_distance / max_distance
-    
-    # 유사도 점수 계산 (1에 가까울수록 유사함)
-    similarity_score = 1 - normalized_distance
-    
+    similarity_score = np.exp(-raw_distance * scale_factor)
+
     return similarity_score
+
+
+if __name__ == '__main__':
+    a = pd.Series([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3000, 6000, 6000, 6000, 6001, 15, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    b = pd.Series([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1500, 3000, 3000, 3000, 3001, 7, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+
+    print(dtw_similarity_score(a, b))


### PR DESCRIPTION
## #️⃣연관된 이슈

#15 

## 📝작업 내용

- 비영 데이터는 DTW 계산에서 제외됩니다.
- 진폭에 따른 영향을 줄이기 위해 데이터를 zscore로 정규화합니다.
- 유사도 값이 0과 1사이의 값으로 보장하기 위해 지수 함수를 이용합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
